### PR TITLE
Updates from review

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A set of Helm exercises actively used by [Eficode Academy](https://www.eficode.c
 
 Natural progression:
 
-- [Intro to helm package manager](intro-to-helm-package-manager.md)
+- [Intro to Kubernetes package manager](intro-to-kubernetes-package-manager.md)
 - [Hello sentences app](hello-sentences-app.md)
 - [Create a helm chart](create-a-helm-chart.md)
 - [Helm release and rollback](release-rollback.md)

--- a/external-charts.md
+++ b/external-charts.md
@@ -305,7 +305,7 @@ Play around with the application again, and verify that the application is worki
 - `helm uninstall my-todo`
 - `kubectl delete pvc data-my-todo-mysql-0` (your pvc name might be different)
 
-#### Resources
+### Resources
 
 https://helm.sh/docs/chart_best_practices/dependencies/#versions
 https://helm.sh/docs/helm/helm_pull/

--- a/external-charts/start/todo/templates/mysql-deployment.yaml
+++ b/external-charts/start/todo/templates/mysql-deployment.yaml
@@ -31,6 +31,8 @@ spec:
           name: mysql
           ports:
             - containerPort: 3306
-          resources: {}
+          resources:
+            limits:
+              memory: 1Gi
       restartPolicy: Always
 status: {}

--- a/helm-chart-with-parameters.md
+++ b/helm-chart-with-parameters.md
@@ -514,3 +514,7 @@ spec:
 ```
 
 </details>
+
+### Clean up
+
+- `helm uninstall sentences`

--- a/helm-lint-kubeval.md
+++ b/helm-lint-kubeval.md
@@ -27,7 +27,6 @@ But we will provide a section with hints in :bulb:.
 The exercise resides in the `helm-lint/start` folder.
 
 - Run `helm lint sentence-app/` to help you identify the problems of the chart.
-- Install the helm plugin [helm kubeval](https://artifacthub.io/packages/helm-plugin/kubeval/kubeval): `helm plugin install https://github.com/instrumenta/helm-kubeval`.
 - Run `helm kubeval sentence-app/` to help you investigate further.
 - Deploy the fixed chart
 
@@ -57,4 +56,7 @@ The exercise resides in the `helm-lint/start` folder.
 ### Clean up
 
 If anything needs cleaning up, here is the section to do just that.
+
+### Resources
+
 https://artifacthub.io/packages/helm-plugin/kubeval/kubeval

--- a/intro-to-kubernetes-package-manager.md
+++ b/intro-to-kubernetes-package-manager.md
@@ -120,16 +120,10 @@ To access NGINX from outside the cluster, follow the steps below:
 
 **Access the Nginx load balanced service**
 
-Get the external IP and port with the following
-three commands.
-> :bulb: You must change `user1` in the below commands to your namespace.
-> You can find your namespace with the command `kubectl config view | grep namespace`.
+Get the external IP/DNS of Nginx with the following commands:
 
-- `export SERVICE_PORT=$(kubectl get --namespace user1 -o jsonpath="{.spec.ports[0].port}" services my-release-nginx)`
-- `export SERVICE_IP=$(kubectl get svc --namespace user1 my-release-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')`
-- `echo "http://${SERVICE_IP}:${SERVICE_PORT}"`
-- Navigate your browser to the url printed out by
-  the last command
+- `kubectl get services`
+- Navigate your browser to the IP/DNS found in the `EXTERNAL-IP` column
 
 **Look at the status of the deployment with `helm`
 and `kubectl`**

--- a/release-rollback.md
+++ b/release-rollback.md
@@ -200,7 +200,7 @@ With a strategic merge, a list is either replaced or merged depending on its pat
 - See that the pods are deployed: `kubectl get pods`
 - Note down the revision number: `helm ls`
 - Add a label to the deployment located in `extra/sentences-age-deployment.yaml`
-- Apply the hand-edited deployment `kubectl apply -f extra/sentences-age-deployment.yaml`
+- Apply the hand-edited deployment (its safe to ignore the warning about a missing annotation) `kubectl apply -f extra/sentences-age-deployment.yaml`
 - See that the revision is still the same `helm ls`
 - See the added label in the cluster `kubectl describe deployments.apps sentence-age `
 - Make an upgrade back to the original version  `helm upgrade myapp sentence-app/`

--- a/sharing-charts/sentence-app/templates/tests/sentence-svc-test.yaml
+++ b/sharing-charts/sentence-app/templates/tests/sentence-svc-test.yaml
@@ -9,5 +9,5 @@ spec:
   restartPolicy: Never
   containers:
     - name: "{{ .Release.Name }}-sentence-svc-test"
-      image: praqma/network-multitool:minimal
+      image: ghcr.io/eficode-academy/network-multitool:latest
       command: ["curl", "-s", "{{ .Values.sentences.service.name }}:{{ .Values.sentences.service.port }}"]

--- a/test-helm-deployments.md
+++ b/test-helm-deployments.md
@@ -85,7 +85,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: "{{ .Release.Name }}-sentence-svc-test"
-      image: praqma/network-multitool:minimal
+      image: ghcr.io/eficode-academy/network-multitool:latest
       command: ["curl", "-s", "sentence:8080"]
 ```
 
@@ -239,7 +239,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: "{{ .Release.Name }}-sentence-svc-test"
-      image: praqma/network-multitool:minimal
+      image: ghcr.io/eficode-academy/network-multitool:latest
       command: ["curl", "-s", "sentence:8080"]
 ```
 

--- a/test-helm-deployments/done/sentence-app/templates/tests/sentence-svc-test.yaml
+++ b/test-helm-deployments/done/sentence-app/templates/tests/sentence-svc-test.yaml
@@ -9,5 +9,5 @@ spec:
   restartPolicy: Never
   containers:
     - name: "{{ .Release.Name }}-sentence-svc-test"
-      image: praqma/network-multitool:minimal
+      image: ghcr.io/eficode-academy/network-multitool:latest
       command: ["curl", "-s", "{{ .Values.sentences.service.name }}:{{ .Values.sentences.service.port }}"]

--- a/trainer/examples/test/svc-test-as-job.yaml
+++ b/trainer/examples/test/svc-test-as-job.yaml
@@ -16,5 +16,5 @@ spec:
       restartPolicy: Never
       containers:
         - name: "{{ .Release.Name }}-sentence-svc-test"
-          image: praqma/network-multitool:minimal
+          image: ghcr.io/eficode-academy/network-multitool:latest
           command: ["curl", "-s", "{{ .Values.sentences.service.name }}:{{ .Values.sentences.service.port }}"]


### PR DESCRIPTION
This PR adds:

- Minor editorial updates
- Change of network-multitool container image to `ghcr.io/eficode-academy/network-multiool`
- Remove installation of `kubeval` - this will be part of infrastructure deployment
- Text adjustments to reflect that on AWS Services of type LoadBalancer use DNS names instead of IPs
-