### PR TITLE
improvement: change 'touch' to 'rm -rf' to avoid misunderstandings

### DIFF
--- a/create-a-helm-chart.md
+++ b/create-a-helm-chart.md
@@ -118,7 +118,7 @@ The `helm create` command we just issued created a lot of files that you might w
 We do not need all of those files for the chart we will be creating, therefore we will remove the files we do not need:
 
 - `rm -rf sentence-app/templates/*`
-- `touch sentence-app/values.yaml`
+- `rm -rf sentence-app/values.yaml`
 
 This provides us with skeleton chart without any
 template files.


### PR DESCRIPTION
I just had a course participant requesting clarification on this as the write up explains that we will remove some unneeded files.

The `helm create` command executed earlier in this exercise creates the file being `touch`ed and as such there is a mismatch between what is written and what is present in the folder.